### PR TITLE
Add CI/CD workflow for backend and frontend builds

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 12-ci-cd-pipeline
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Lisab CI/CD pipeline’i backend’i ja frontend’i jaoks:

**Backend:** 
- Maven build ilma testideta (`install -DskipTests`), sest need hetkel feilivad
- Docker image’i loomine (ux-hell-backend:latest).

**Frontend:** 
- Install pnpm dependencies,
-  lintimine 
-  build